### PR TITLE
fix: typo in binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ because `α` is not a type.
   Maybe something like this:
 ```lean
 def turnExistsIntoForall : Q(Prop) → MetaM Q(Prop)
-  | ~q(∃ x, p x) => do
+  | ~q(∃ x, $p x) => do
      q(∀ x, $(x => turnExistsIntoForall q($p $x)))
   | e => e
 ```


### PR DESCRIPTION
The syntax is hypothetical, but it appears either way the antiquotation pattern should be there (please close if not).