### PR TITLE
chore: add lakefile.olean to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /build
+/lakefile.olean


### PR DESCRIPTION
When we compile `quote4` as a dependency, the `lakefile.olean` gets created, and then pollutes output from tools that watch git repositories (e.g. in VSCode we see the `lake-package/Qq/lakefile.olean` showing up when viewing Mathlib).