### PR TITLE
add support for the no-op `generalizing := true`

### DIFF
--- a/examples/matching.lean
+++ b/examples/matching.lean
@@ -59,3 +59,12 @@ def pairLit (u : Lean.Level) (α : Q(Type u)) (a : Q($α)) : MetaM Q($α × $α)
   | _, _, _ => failure
 
 #eval show MetaM Unit from do guard <| (←pairLit _ _ q(2)) == q((2, 2))
+
+-- `generalizing := true` is a no-op
+def pairLit' (u : Lean.Level) (α : Q(Type u)) (a : Q($α)) : MetaM Q($α × $α) := do
+  match (generalizing := true) u, α, a with
+  | 0, ~q(Nat), n => return q(($n, $n))
+  | 0, ~q(Int), z => return q(($z, $z))
+  | _, _, _ => failure
+
+#eval show MetaM Unit from do guard <| (←pairLit' _ _ q(2)) == q((2, 2))


### PR DESCRIPTION
This fixes #29, and gives a clearer error on `generalizing := false`