### PR TITLE
feat: add lake-manifest.json, update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /build
 /lakefile.olean
 /.lake
-/lake-manifest.json

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -1,0 +1,5 @@
+{"version": 7,
+ "packagesDir": ".lake/packages",
+ "packages": [],
+ "name": "Qq",
+ "lakeDir": ".lake"}


### PR DESCRIPTION
As the title says, I have added lake-manifest.json by running `lake update`. I have also updated `.gitignore` to not ignore the manifest. If required, the .gitignore change can be undone.

For relevant discussion see the [linked zulip thread](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Qq.20manifest.20warning.20in.20new.20math.20project/near/436974243)