### PR TITLE
chore: remove unnecessary 'open'; compatibility with v4.11.0-rc3

### DIFF
--- a/Qq/Macro.lean
+++ b/Qq/Macro.lean
@@ -9,7 +9,7 @@ This file provides the main feature of `Qq`; the `q( )` and `Q( )` macros,
 which are available with `open scoped Qq`.
 -/
 
-open Lean Meta Std
+open Lean Meta
 
 namespace Qq
 


### PR DESCRIPTION
This `open` statement is unneeded, and if we remove it then we gain compatibility with `v4.11.0-rc3` (where `Std.HashMap` and `Lean.HashMap` clash).