### PR TITLE
Remove the ToExpr Int instance

### DIFF
--- a/Qq/ForLean/ToExpr.lean
+++ b/Qq/ForLean/ToExpr.lean
@@ -2,12 +2,6 @@ import Lean
 
 open Lean
 
-instance : ToExpr Int where
-  toTypeExpr := .const ``Int []
-  toExpr i := match i with
-    | .ofNat n => mkApp (.const ``Int.ofNat []) (toExpr n)
-    | .negSucc n => mkApp (.const ``Int.negSucc []) (toExpr n)
-
 instance : ToExpr MVarId where
   toTypeExpr := .const ``MVarId []
   toExpr i := mkApp (.const ``MVarId.mk []) (toExpr i.name)


### PR DESCRIPTION
This instance exists both upstream in core and downstream in mathlib (see [Zulip](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Lean.2EToExpr.20Int/near/474914783)).

The one upstream uses `toExpr (-1) = q(-1)`, which is probably preferable to the `toExpr (-1) = q(Int.negSucc 0)` used here.