### PR TITLE
feat: generalize `ReduceEval (Fin n)` to use `NeZero`

### DIFF
--- a/Qq/ForLean/ReduceEval.lean
+++ b/Qq/ForLean/ReduceEval.lean
@@ -17,11 +17,11 @@ private partial def evalList [ReduceEval α] (e : Expr) : MetaM (List α) := do
 
 instance [ReduceEval α] : ReduceEval (List α) := ⟨evalList⟩
 
-instance : ReduceEval (Fin (n+1)) where
+instance [NeZero n] : ReduceEval (Fin n) where
   reduceEval := fun e => do
     let e ← whnf e
     if e.isAppOfArity ``Fin.mk 3 then
-      return Fin.ofNat (← reduceEval (e.getArg! 1))
+      return Fin.ofNat' _ (← reduceEval (e.getArg! 1))
     else
       throwFailedToEval e
 

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.12.0-rc1
+leanprover/lean4:v4.13.0-rc3


### PR DESCRIPTION
This requires a toolchain bump.