### PR TITLE
feat: add `ReduceEval (BitVec n)` instance

### DIFF
--- a/examples/misc.lean
+++ b/examples/misc.lean
@@ -19,3 +19,14 @@ example : Q(let x := 5; x = x) := q(by simp)
 
 def foo' (n : Nat) : Q(Q($($n) = $($n))) := q(q(by simp))
 #eval foo' 3
+
+#eval (Meta.ReduceEval.reduceEval q(15 + 7 : Fin (2 ^ 4)) : MetaM (Fin (2 ^ 4)))
+#eval (Meta.ReduceEval.reduceEval q(15#4 + 7#4 : BitVec 4) : MetaM (BitVec 4))
+#eval (Meta.ReduceEval.reduceEval q(15 + 7 : UInt64) : MetaM UInt64)
+
+/--
+error: typeclass instance problem is stuck, it is often due to metavariables
+  Meta.ReduceEval ?m.2036
+-/
+#guard_msgs in
+#eval Meta.ReduceEval.reduceEval q(15 : USize)

--- a/examples/misc.lean
+++ b/examples/misc.lean
@@ -25,8 +25,10 @@ def foo' (n : Nat) : Q(Q($($n) = $($n))) := q(q(by simp))
 #eval (Meta.ReduceEval.reduceEval q(15 + 7 : UInt64) : MetaM UInt64)
 
 /--
-error: typeclass instance problem is stuck, it is often due to metavariables
-  Meta.ReduceEval ?m.2036
+error: reduceEval: failed to evaluate argument
+  match (USize.toBitVec 15).toNat + (USize.toBitVec 7).toNat, 2 ^ System.Platform.numBits with
+  | 0, x => 0
+  | n@h:n_1.succ, m => if m ≤ n then n.modCore m else n
 -/
 #guard_msgs in
-#eval Meta.ReduceEval.reduceEval q(15 : USize)
+#eval (Meta.ReduceEval.reduceEval q(15 + 7 : USize) : MetaM USize)

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.13.0-rc3
+leanprover/lean4:nightly-2024-10-17


### PR DESCRIPTION
This PR addresses a breaking change introduced in [leanprover/lean4#5323](https://github.com/leanprover/lean4/pull/5323), where `UInt64` is redefined in terms of `BitVec 64` instead of `Fin (2 ^ 64)`. The toolchain has been updated to the earliest nightly version (2024-10-17) that includes this breaking change.