### PR TITLE
refactor: avoid using `LocalDecl` constructors directly

### DIFF
--- a/Qq/Macro.lean
+++ b/Qq/Macro.lean
@@ -197,7 +197,7 @@ def makeZetaReduce (a : FVarId) (b : Expr) : MetaM (Option LocalContext) := do
   for y in toRevert do if bFVars.fvarSet.contains y then return none
   let oldLCtx ← getLCtx
   let newLCtx := toRevert.foldl (init := oldLCtx) (·.erase ·)
-  let newLCtx := newLCtx.addDecl <| .ldecl aIdx aFVarId aUserName aType b (nonDep := false) aKind
+  let newLCtx := newLCtx.addDecl <| .ldecl aIdx aFVarId aUserName aType b (nondep := false) aKind
   let newLCtx := toRevert.filter (· != a) |>.foldl (init := newLCtx) (·.addDecl <| oldLCtx.get! ·)
   return newLCtx
 

--- a/Qq/Match.lean
+++ b/Qq/Match.lean
@@ -135,7 +135,7 @@ def mkIsDefEq (decls : List PatVarDecl) (pat discr : Q(Expr)) : MetaM Q(MetaM $(
 
 def withLetHave [Monad m] [MonadControlT MetaM m] [MonadLiftT MetaM m] [MonadLCtx m]
     (fvarId : FVarId) (userName : Name) (val : (Quoted α)) (k : (Quoted α) → m (Quoted β)) : m (Quoted β) := do
-  withExistingLocalDecls [LocalDecl.cdecl (← getLCtx).decls.size fvarId userName α .default .default] do
+  withExistingLocalDecls [LocalDecl.cdecl default fvarId userName α .default .default] do
     return Quoted.unsafeMk $ ← mkLet' userName (.fvar fvarId) α val (← k (.fvar fvarId))
 
 def mkQqLets {γ : Q(Type)} : (decls : List PatVarDecl) → Q($(mkIsDefEqType decls)) →

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.21.0-rc3
+leanprover/lean4-pr-releases:pr-release-8804-0b63061

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4-pr-releases:pr-release-8804-0b63061
+leanprover/lean4:v4.21.0-rc3


### PR DESCRIPTION
This PR does the following things:
- It ensures Qq is compatible with upcoming Lean changes (https://github.com/leanprover/lean4/pull/8804).
- It switches to `LocalContext.mkLetDecl`/`LocalContext.mkLocalDecl` when possible.
- It removes the local decl index calculation that is overwritten by `withExistingLocalDecls` anyway.