### PR TITLE
fix: don't fail delaboration with errors

### DIFF
--- a/Qq/Delab.lean
+++ b/Qq/Delab.lean
@@ -20,6 +20,7 @@ register_option pp.qq : Bool := {
 }
 
 -- TODO: this probably exists in the library
+@[inline]
 private meta def failureOnError {m : Type u → Type v} {n : Type u → Type w}
     [Monad n] [MonadLiftT m n] [Alternative m] [Alternative n] (x : m α) : n α := do
   (← liftM (optional x)).getDM failure
@@ -33,7 +34,6 @@ meta instance : MonadLift UnquoteM (StateT UnquoteState DelabM) where
 
 meta def delabQuoted : StateT UnquoteState DelabM Term := do
   let e ← getExpr
-  -- `(failure : DelabM _)` is of course completely different than `(failure : MetaM _)`...
   let newE ← failureOnError (unquoteExpr e)
   let newLCtx := (← get).unquoted
   withLCtx newLCtx (← determineLocalInstances newLCtx) do

--- a/Qq/Delab.lean
+++ b/Qq/Delab.lean
@@ -20,16 +20,9 @@ register_option pp.qq : Bool := {
 }
 
 -- TODO: this probably exists in the library
-private meta def failureOnError (x : MetaM α) : DelabM α := do
-  let y : MetaM (Option α) := do try return some (← x) catch _ => return none
-  match ← y with
-    | some a => return a
-    | none => failure
-
-private meta def unquote (e : Expr) : UnquoteM (Expr × LocalContext) := do
-  unquoteLCtx
-  let newE ← unquoteExpr e
-  return (newE, (← get).unquoted)
+private meta def failureOnError {m : Type u → Type v} {n : Type u → Type w}
+    [Monad n] [MonadLiftT m n] [Alternative m] [Alternative n] (x : m α) : n α := do
+  (← liftM (optional x)).getDM failure
 
 meta def checkQqDelabOptions : DelabM Unit := do
   unless ← getPPOption (·.getBool `pp.qq true) do failure
@@ -41,7 +34,7 @@ meta instance : MonadLift UnquoteM (StateT UnquoteState DelabM) where
 meta def delabQuoted : StateT UnquoteState DelabM Term := do
   let e ← getExpr
   -- `(failure : DelabM _)` is of course completely different than `(failure : MetaM _)`...
-  let some newE ← (try some <$> unquoteExpr e catch _ => failure : UnquoteM _) | failure
+  let newE ← failureOnError (unquoteExpr e)
   let newLCtx := (← get).unquoted
   withLCtx newLCtx (← determineLocalInstances newLCtx) do
     withTheReader SubExpr (fun s => { s with expr := newE }) delab
@@ -50,7 +43,7 @@ meta def withDelabQuoted (k : StateT UnquoteState DelabM Term) : Delab :=
   withIncRecDepth do
   StateT.run' (s := { mayPostpone := false }) <|
   show StateT UnquoteState DelabM Term from do
-  unquoteLCtx
+  failureOnError unquoteLCtx
   let mut res ← k
   let showNested := `pp.qq._nested
   if (← getOptions).get showNested true then

--- a/QqTest/matchMotive.lean
+++ b/QqTest/matchMotive.lean
@@ -1,18 +1,8 @@
 import Qq
 open Qq Lean
 
-open Elab Term in
-elab tk:"showTerm" t:term : term <= expectedType => do
-  let t' ← withSynthesize do elabTerm t expectedType
-  logAt tk t' (severity := MessageSeverity.information)
-  return t'
-
-/--
-info: failed to pretty print expression (use 'set_option pp.rawOnError true' for raw representation)
--/
-#guard_msgs in
 def provePositive (n : Q(Nat)) : MetaM Q(0 < $n) :=
-  showTerm match n with
+  match n with
     | ~q($m + 1) => pure q(Nat.lt_of_le_of_lt (Nat.zero_le _) (Nat.lt_succ_self _))
     | ~q(1 + $m) => pure q(by
         show 0 < 1 + $m


### PR DESCRIPTION
Previously, viewing the definition of `Quoted.ty` with Qq delaboration enabled caused errors during delaboration that made the signature completely invisible and the expected type view show an error. Instead, we should just let normal application delaboration take over.