### PR TITLE
docs: antiquote α in betterApp README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ set_option trace.compiler.ir.result true in
 -- `autoBoundImplicitLocal`.
 
 def betterApp {α : Q(Sort u)} {β : Q($α → Sort v)}
-  (f : Q((a : α) → $β a)) (a : Q($α)) : Q($β $a) :=
+  (f : Q((a : $α) → $β a)) (a : Q($α)) : Q($β $a) :=
 q($f $a)
 
 #eval betterApp q(Int.toNat) q(42)


### PR DESCRIPTION
## Summary
- Change `Q((a : α) → $β a)` to `Q((a : $α) → $β a)` so the README example typechecks with current Lean.

Fixes #57.

## Test plan
- [ ] Paste the updated example into a quote4 project and confirm it elaborates

Made with [Cursor](https://cursor.com)