### PR TITLE
fix: treat none as a refutable qq match pattern

### DIFF
--- a/Qq/Match.lean
+++ b/Qq/Match.lean
@@ -268,6 +268,7 @@ partial def isIrrefutablePattern : Term → Bool
   | `(($a, $b)) => isIrrefutablePattern a && isIrrefutablePattern b
   | `(_) => true
   | `(true) => false | `(false) => false -- TODO properly
+  | `(none) => false -- nullary Option ctor is refutable, like Bool
   | stx => stx.1.isIdent
 
 scoped elab "_comefrom" n:ident "do" b:doSeq " in " body:term : term <= expectedType => do


### PR DESCRIPTION
## Summary
- `isIrrefutablePattern` treated `none` like a binder ident, so failing Option matches skipped the alternative.
- Classify `none` as refutable.

## Test plan
- [ ] qq match on `none` with a non-none discr takes the alt branch
- [ ] Existing true/false / ident patterns unchanged
